### PR TITLE
Fixing text domain issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,18 @@
 <img src="http://i.imgur.com/XqYZcTA.png" width="680" height="349" />
 
 ### What problem does this solve?
+
 If you make changes to a theme, those changes will be lost when the theme is updated.
 With a child theme, your changes are kept separate, so the parent theme can be safely updated.
+
+---
 
 ### How it works
 
 * If a child theme is not active, the user will see a WP notice with an "Activate" link **on the Theme Editor screen**
 * When clicked, a child theme is created (if needed) and enabled
+
+---
 
 ### Setup
 
@@ -18,6 +23,14 @@ If you're a theme developer, include `use-child-theme.php` in your theme, then a
 ```php
 require_once( trailingslashit( get_template_directory() ) . 'use-child-theme.php' );
 ```
+
+#### Important:
+
+You need to change `YOUR_THEME_SLUG` text domain in the `use-child-theme.php` file to match your (parent) theme folder name! Please, use a search & replace functionality of your code editor for that.
+
+This is *required for you theme to pass WordPress.org theme review* (you can test your theme with [**Theme Check** plugin](https://wordpress.org/plugins/theme-check/)).
+
+---
 
 ### Changelog
 

--- a/use-child-theme.php
+++ b/use-child-theme.php
@@ -2,6 +2,11 @@
 /*
  * Use Child Theme
  * A drop-in to make it easy to use WordPress child themes
+ *
+ * Important:
+ * Don't forget to change `YOUR_THEME_SLUG` text domain to match
+ * your (parent) theme folder name.
+ *
  * @version 0.4
  */
 

--- a/use-child-theme.php
+++ b/use-child-theme.php
@@ -126,7 +126,7 @@ if ( ! class_exists( 'Use_Child_Theme' ) && is_admin() ) {
                 update_option( 'theme_mods_' . $this->child_slug, $parent_settings );
             }
 
-            wp_die( esc_html__( 'All done!', 'YOUR_THEME_SLUG' ) );
+            wp_die( esc_html__( 'All done! You are using a child theme now!', 'YOUR_THEME_SLUG' ) );
         }
 
 

--- a/use-child-theme.php
+++ b/use-child-theme.php
@@ -78,8 +78,8 @@ if ( ! class_exists( 'Use_Child_Theme' ) && is_admin() ) {
 
         <div class="notice notice-error uct-notice is-dismissible">
             <p>
-                <?php printf( esc_html__( 'Please use a %s child theme to make changes', 'use-child-theme' ), $this->theme->get( 'Name' ) ); ?>
-                <a class="uct-activate" href="javascript:;"><?php esc_html_e( 'Activate now', 'use-child-theme' ); ?></a>
+                <?php printf( esc_html__( 'Please use a %s child theme to make changes', 'YOUR_THEME_SLUG' ), $this->theme->get( 'Name' ) ); ?>
+                <a class="uct-activate" href="javascript:;"><?php esc_html_e( 'Activate now', 'YOUR_THEME_SLUG' ); ?></a>
             </p>
         </div>
 <?php
@@ -126,7 +126,7 @@ if ( ! class_exists( 'Use_Child_Theme' ) && is_admin() ) {
                 update_option( 'theme_mods_' . $this->child_slug, $parent_settings );
             }
 
-            wp_die( esc_html__( 'All done!', 'use-child-theme' ) );
+            wp_die( esc_html__( 'All done!', 'YOUR_THEME_SLUG' ) );
         }
 
 
@@ -147,7 +147,7 @@ if ( ! class_exists( 'Use_Child_Theme' ) && is_admin() ) {
                 }
             }
             else {
-                wp_die( esc_html__( 'Error: theme folder not writable', 'use-child-theme' ) );
+                wp_die( esc_html__( 'Error: theme folder not writable', 'YOUR_THEME_SLUG' ) );
             }
         }
 


### PR DESCRIPTION
- Renaming a text domain from `use-child-theme` to `YOUR_THEME_SLUG` for easier search & replace
- Adding information about text domain into `use-child-theme.php` file docblock and into readme file
- Improving organization of readme file
- Updating successful message text

**Fixes issue:** #14 
